### PR TITLE
Add go1.18 and go1.19 test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.16', '1.17', '1.18', '1.19']
         platform: [ubuntu-latest, macos-latest] # can not run in windows OS
     runs-on: ${{ matrix.platform }}
 

--- a/copier.go
+++ b/copier.go
@@ -176,26 +176,27 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 		return
 	}
 
-	if from.Kind() == reflect.Slice && to.Kind() == reflect.Slice && fromType.ConvertibleTo(toType) {
+	if from.Kind() == reflect.Slice && to.Kind() == reflect.Slice {
 		if to.IsNil() {
 			slice := reflect.MakeSlice(reflect.SliceOf(to.Type().Elem()), from.Len(), from.Cap())
 			to.Set(slice)
 		}
+		if fromType.ConvertibleTo(toType) {
+			for i := 0; i < from.Len(); i++ {
+				if to.Len() < i+1 {
+					to.Set(reflect.Append(to, reflect.New(to.Type().Elem()).Elem()))
+				}
 
-		for i := 0; i < from.Len(); i++ {
-			if to.Len() < i+1 {
-				to.Set(reflect.Append(to, reflect.New(to.Type().Elem()).Elem()))
-			}
-
-			if !set(to.Index(i), from.Index(i), opt.DeepCopy, converters) {
-				// ignore error while copy slice element
-				err = copier(to.Index(i).Addr().Interface(), from.Index(i).Interface(), opt)
-				if err != nil {
-					continue
+				if !set(to.Index(i), from.Index(i), opt.DeepCopy, converters) {
+					// ignore error while copy slice element
+					err = copier(to.Index(i).Addr().Interface(), from.Index(i).Interface(), opt)
+					if err != nil {
+						continue
+					}
 				}
 			}
+			return
 		}
-		return
 	}
 
 	if fromType.Kind() != reflect.Struct || toType.Kind() != reflect.Struct {
@@ -209,6 +210,11 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 			amount = from.Len()
 		}
 	}
+
+	//if to.IsNil() {
+	//	slice := reflect.MakeSlice(reflect.SliceOf(to.Type().Elem()), from.Len(), from.Cap())
+	//	to.Set(slice)
+	//}
 
 	for i := 0; i < amount; i++ {
 		var dest, source reflect.Value

--- a/copier.go
+++ b/copier.go
@@ -211,11 +211,6 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 		}
 	}
 
-	//if to.IsNil() {
-	//	slice := reflect.MakeSlice(reflect.SliceOf(to.Type().Elem()), from.Len(), from.Cap())
-	//	to.Set(slice)
-	//}
-
 	for i := 0; i < amount; i++ {
 		var dest, source reflect.Value
 

--- a/copier.go
+++ b/copier.go
@@ -263,7 +263,8 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 					// process for nested anonymous field
 					destFieldNotSet := false
 					if f, ok := dest.Type().FieldByName(destFieldName); ok {
-						for idx := range f.Index {
+						// only initialize parent embedded struct pointer in the path
+						for idx := range f.Index[:len(f.Index)-1] {
 							destField := dest.FieldByIndex(f.Index[:idx+1])
 
 							if destField.Kind() != reflect.Ptr {

--- a/copier_test.go
+++ b/copier_test.go
@@ -1666,3 +1666,33 @@ func TestSqlNullFiled(t *testing.T) {
 		t.Errorf("to (%v) value should equal from (%v) value", to.MkExpiryDateType, from.MkExpiryDateType.Int32)
 	}
 }
+
+func TestEmptySlice(t *testing.T) {
+	type Str1 string
+	type Str2 string
+	type Input1 struct {
+		Val Str1
+	}
+	type Input2 struct {
+		Val Str2
+	}
+	to := []*Input1(nil)
+	from := []*Input2{}
+	err := copier.Copy(&to, &from)
+	if err != nil {
+		t.Error("should not error")
+	}
+	if from == nil {
+		t.Error("from should be empty slice not nil")
+	}
+
+	to = []*Input1(nil)
+	from = []*Input2(nil)
+	err = copier.Copy(&to, &from)
+	if err != nil {
+		t.Error("should not error")
+	}
+	if from != nil {
+		t.Error("from should be empty slice nil")
+	}
+}


### PR DESCRIPTION
- Invalid sql.Null* values should be copied to pointer field as nil
- Embedded struct should be initialized if its member is copied directly
- Add test cases to cover the above cases